### PR TITLE
website: PMTiles server and f16 shader support

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,6 @@
     "accessible-nprogress": "^2.1.2",
     "geotiff": "^2.1.4-beta.1",
     "maplibre-gl": "^5.11.0",
-    "pmtiles": "^4.3.0",
     "proj4": "^2.20.2",
     "svelte": "^5.42.2",
     "svelte5-router": "^3.0.2"
@@ -27,6 +26,7 @@
     "@rsbuild/core": "^1.6.0",
     "@rsbuild/plugin-sass": "^1.4.0",
     "@rsbuild/plugin-svelte": "^1.0.11",
+    "pmtiles": "^4.3.0",
     "prettier": "^3.6.2",
     "svelte-check": "^4.3.3",
     "typescript": "^5.9.3"

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       maplibre-gl:
         specifier: ^5.11.0
         version: 5.13.0
-      pmtiles:
-        specifier: ^4.3.0
-        version: 4.3.0
       proj4:
         specifier: ^2.20.2
         version: 2.20.2
@@ -45,6 +42,9 @@ importers:
       '@rsbuild/plugin-svelte':
         specifier: ^1.0.11
         version: 1.0.11(@rsbuild/core@1.6.7)(postcss@8.5.6)(sass@1.93.3)(svelte@5.43.14)(typescript@5.9.3)
+      pmtiles:
+        specifier: ^4.3.0
+        version: 4.3.0
       prettier:
         specifier: ^3.6.2
         version: 3.6.2

--- a/website/src/Home.svelte
+++ b/website/src/Home.svelte
@@ -42,6 +42,10 @@
 				The lines are the theoretical ideals. They rely on perfect weather
 				conditions and favourable refraction.
 			</p>
+			<p>
+				Heatmap colours: the brighter the more and further you can see. The
+				darker the less you can see.
+			</p>
 		</CollapsableModal>
 
 		{#if state.longest_line}

--- a/website/src/fragment.glsl
+++ b/website/src/fragment.glsl
@@ -1,11 +1,20 @@
+#version 300 es
 precision highp float;
-varying vec2 v_texcoord;
-uniform sampler2D u_data;
+precision highp usampler2D;
+
+in vec2 v_texcoord;
+uniform usampler2D u_data;
 uniform float u_max;
 uniform float u_averageSurfaceVisibility;
 
+out vec4 fragColor;
+
 void main() {
-    float value = texture2D(u_data, v_texcoord).r;
+    vec3 final_color;
+
+    uvec2 rg = texelFetch(u_data, ivec2(v_texcoord * 256.0), 0).rg;
+    uint bits = (rg.g << 16) | rg.r;
+    float value = uintBitsToFloat(bits);
 
     // Handle "nodata"
     if (value == 0.0) {
@@ -19,8 +28,6 @@ void main() {
     vec3 color_mid = vec3(0.5, 0.5, 0.5);
     vec3 color_max = vec3(1.0, 1.0, 1.0);
 
-    vec3 final_color;
-
     if (normalized_v < 0.5) {
         float half_normalized = normalized_v / 0.5;
         final_color = mix(color_min, color_mid, half_normalized);
@@ -29,5 +36,5 @@ void main() {
         final_color = mix(color_mid, color_max, half_normalized);
     }
 
-    gl_FragColor = vec4(final_color, 1.0);
+    fragColor = vec4(final_color, 1.0);
 }

--- a/website/src/utils.ts
+++ b/website/src/utils.ts
@@ -1,6 +1,11 @@
 import { LngLat, LngLatBounds } from 'maplibre-gl';
 
-export const BUCKET = 'https://viewview.nyc3.cdn.digitaloceanspaces.com';
+export const CDN_BUCKET = 'https://cdn.alltheviews.world';
+export const MAP_SERVER = 'https://map.alltheviews.world';
+export const WORLD_PMTILES = 'world';
+export const PMTILES_SERVER = `${MAP_SERVER}/runs/0.1/pmtiles/${WORLD_PMTILES}`;
+
+export const VERSION = '0.1';
 export const EARTH_RADIUS = 6371_000.0;
 
 export const Log = {
@@ -80,4 +85,11 @@ export function toDegrees(radians: number) {
 export function lonLatRound(lonlat: LngLat) {
   const precision = 6;
   return [lonlat.lng.toPrecision(precision), lonlat.lat.toPrecision(precision)];
+}
+
+export function packFloatToU16s(float: number) {
+  const buffer = new ArrayBuffer(4);
+  new Float32Array(buffer)[0] = float;
+  const u16s = new Uint16Array(buffer);
+  return u16s;
 }

--- a/website/src/vertex.glsl
+++ b/website/src/vertex.glsl
@@ -1,10 +1,14 @@
+#version 300 es
 precision highp float;
-attribute vec2 a_pos;
+
+in vec2 a_pos;
+out vec2 v_texcoord;
+
 uniform mat4 u_projectionMatrix;
 uniform vec4 u_tileMatrix;
 uniform float u_scale;
 uniform vec2 u_offset;
-varying vec2 v_texcoord;
+
 void main() {
     vec2 normalised_coord = a_pos / 4096.0;
     v_texcoord = normalised_coord / u_scale + u_offset;

--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -1,0 +1,8 @@
+{
+  "name": "viewview",
+  "compatibility_date": "2025-12-05",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application"
+  }
+}


### PR DESCRIPTION
The PMTiles server is a Cloudflare worker, not included in this repo, but it allows fetching the .pmtile data with `z/x/y` URLs. These are normal HTTP requests (as opposed to HTTP range requests) and so can be cached by browsers, CDNs etc.

The `f16` shader support is a fix to allow browsers that don't support single `f32` shader textures to still process `f32` data via packed data in the red and green channels of a shader texture. This should fix a few browsers that couldn't display the heatmap, most notably Chrome.