### PR TITLE
feat: longest lines overviews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float_eq"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a80e3145d8ad11ba0995949bbcf48b9df2be62772b3d351ef017dff6ecb853"
+
+[[package]]
 name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +1419,25 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "h3o"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60271ce96dbb45e1ac18955e1b44e9e04dcea01df040819efdedc56c0058c367"
+dependencies = [
+ "ahash",
+ "either",
+ "float_eq",
+ "h3o-bit",
+ "libm",
+]
+
+[[package]]
+name = "h3o-bit"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b42eb4efef1f96510ae1a33b2682562a677d504641e9903a77bf5c666b9013e"
 
 [[package]]
 name = "hash32"
@@ -3476,9 +3501,11 @@ dependencies = [
  "clap",
  "color-eyre",
  "dashmap",
+ "futures",
  "gdal",
  "geo",
  "geojson",
+ "h3o",
  "proj4rs",
  "rstar",
  "serde",

--- a/crates/tasks/Cargo.toml
+++ b/crates/tasks/Cargo.toml
@@ -13,9 +13,11 @@ axum = { version = "0.8", features = ["json", "tokio", "query"] }
 bytemuck = { version = "1.23.2", features = ["derive"] }
 clap = { version = "4.5.47", features = ["derive"] }
 color-eyre = "0.6.5"
+futures = "0.3.31"
 gdal = "0.18.0"
 geo = "0.31.0"
 geojson = { version = "0.24.2", features = ["geo-types"] }
+h3o = "0.9.4"
 proj4rs = { version = "0.1.9", features = ["aeqd"] }
 rstar = "0.12.2"
 serde = "1.0.219"

--- a/crates/tasks/src/atlas/longest_lines/grided.rs
+++ b/crates/tasks/src/atlas/longest_lines/grided.rs
@@ -1,0 +1,44 @@
+//! A single Uber H3 grid item that contains the longest line of sight within the extent of that
+//! grid item.
+
+use color_eyre::Result;
+use tokio::io::AsyncWriteExt as _;
+
+/// The filename for the longest lines grid.
+pub const LONGEST_LINES_GRIDED_FILENAME: &str = "longest_lines_grided.bin";
+
+/// The longest line of sight in an H3 grid cell.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Zeroable, bytemuck::Pod)]
+pub struct Grided {
+    /// Longtitude
+    pub lon: f32,
+    /// Latitude
+    pub lat: f32,
+    /// The distance of the line of sight in meters.
+    pub distance: u32,
+}
+
+/// Write the grided longest lines of sight to a binary file ready to be hosted on a CDN and
+/// consumed by the website.
+pub async fn write(path: std::path::PathBuf, world: &[Grided], run_id: &str) -> Result<()> {
+    tracing::debug!("Writing `{path:?}`");
+    let bytes = bytemuck::cast_slice(world);
+    let mut file = tokio::fs::File::create(path.clone()).await?;
+    file.write_all(bytes).await?;
+
+    sync_to_s3(path, run_id).await?;
+
+    Ok(())
+}
+
+/// Sync the longest lines grid to S3.
+async fn sync_to_s3(source: std::path::PathBuf, run_id: &str) -> Result<()> {
+    let destination =
+        format!("s3://viewview/runs/{run_id}/longest_lines_cogs/{LONGEST_LINES_GRIDED_FILENAME}");
+    crate::atlas::machines::local::Machine::connection()
+        .sync_file_to_s3(&source.display().to_string(), &destination)
+        .await?;
+
+    Ok(())
+}

--- a/crates/tasks/src/atlas/longest_lines/overview.rs
+++ b/crates/tasks/src/atlas/longest_lines/overview.rs
@@ -1,0 +1,303 @@
+//! Create an overview of the world's longest lines.
+//!
+//! We grid the world using Uber's hexagonal H3 grids. We use zoom level 4 which means there are a
+//! total of 341,162 grids, each one covering around 65kmx65km. For each grid we find the longest
+//! line of sight in it. We then save all the lines of sight, just their coordinates and length,
+//! in a single bin file for use by the website.
+
+use std::sync::Arc;
+
+use color_eyre::{Result, eyre::ContextCompat as _};
+
+/// A longest in a single H3 grid.
+#[derive(Debug, Clone, Copy)]
+struct LongestLine {
+    /// The coordinates of the line.
+    lonlat: crate::projector::LonLatCoord,
+    /// The raster coordinates of the line in its containing COG. Used mostly for debugging
+    /// because different COG can contain the same line.
+    coord: geo::Coord,
+    /// The bit-packed data for the line (angle and distance).
+    packed: super::packed::LineOfSight,
+}
+
+/// A hash where each key is an H3 grid cell and its value is the longest line of sight within
+/// that grid cell.
+type HashMap = std::collections::HashMap<h3o::CellIndex, LongestLine>;
+
+/// Keep track of the current longest line in each H3 grid.
+type StateHash = Arc<tokio::sync::RwLock<HashMap>>;
+
+/// Representation of a longest lines COG file.
+struct Tile {
+    /// The AEQD to lon/lat coordinate converter
+    projector: crate::projector::Convert,
+    /// The raw point data for the tile
+    buffer: gdal::raster::Buffer<f32>,
+    /// The width of the tile in points
+    width: usize,
+    /// Offset to the centre of the tile in points.
+    offset: f64,
+}
+
+impl Tile {
+    /// Entrypoint.
+    fn process(path: &std::path::Path) -> Result<HashMap> {
+        let centre = Self::parse_centre_coords(path)?;
+        let buffer = Self::load(path)?;
+        let width = buffer.width();
+        #[expect(
+            clippy::cast_precision_loss,
+            clippy::as_conversions,
+            reason = "There's no other way"
+        )]
+        let offset = width as f64 / 2.0f64;
+        let tile = Self {
+            projector: crate::projector::Convert { base: centre },
+            buffer,
+            width,
+            offset,
+        };
+
+        let local = tile.find_longest_lines()?;
+
+        Ok(local)
+    }
+
+    /// Get the lon/lat coordinates representing the centre of the longest lines COG.
+    fn parse_centre_coords(path: &std::path::Path) -> Result<crate::projector::LonLatCoord> {
+        let filestem = path
+            .file_stem()
+            .context("Couldn't get file stem of longest lines tile")?
+            .display()
+            .to_string();
+        let parts: Vec<&str> = filestem.split('_').collect();
+
+        #[expect(
+            clippy::get_first,
+            reason = "Better to have the consistent access method."
+        )]
+        let lon: f64 = parts
+            .get(0)
+            .context("Longitude not present in path parts")?
+            .parse()?;
+        let lat: f64 = parts
+            .get(1)
+            .context("Latitude not present in path parts")?
+            .parse()?;
+        let coord = crate::projector::LonLatCoord(geo::coord! {x: lon, y: lat});
+
+        Ok(coord)
+    }
+
+    /// Load a longest lines COG file.
+    fn load(path: &std::path::Path) -> Result<gdal::raster::Buffer<f32>> {
+        tracing::trace!("Loading {path:?}");
+
+        let dataset = gdal::Dataset::open(path)?;
+        let band = dataset.rasterband(1)?;
+
+        let buffer: gdal::raster::Buffer<f32> =
+            band.read_as((0, 0), band.size(), band.size(), None)?;
+
+        Ok(buffer)
+    }
+
+    /// Iterate through every longest line in COG, associate it with a H3 grid, check to see if
+    /// it's the longest in the grid and set record it if so.
+    fn find_longest_lines(&self) -> Result<HashMap> {
+        tracing::trace!("Looping through {} points", self.buffer.len());
+
+        let mut local = HashMap::new();
+        for (index, &value) in self.buffer.data().iter().enumerate() {
+            let coord = self.index_to_coord(index);
+            let lonlat = self.coord_to_lonlat(coord)?;
+            let cell = h3o::LatLng::new(lonlat.0.y, lonlat.0.x)?.to_cell(h3o::Resolution::Four);
+
+            let current = super::packed::LineOfSight(value);
+            let longest_line = LongestLine {
+                coord,
+                lonlat,
+                packed: current,
+            };
+
+            let Some(existing) = local.get(&cell) else {
+                local.insert(cell, longest_line);
+                continue;
+            };
+
+            if current.distance() > existing.packed.distance() {
+                local.insert(cell, longest_line);
+            }
+        }
+
+        Ok(local)
+    }
+
+    /// Convert a 1D index to a 2D coordinate.
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::as_conversions,
+        reason = "There's no other way"
+    )]
+    const fn index_to_coord(&self, index: usize) -> geo::Coord {
+        geo::coord! {
+            x: index.rem_euclid(self.width) as f64,
+            y: index.div_euclid(self.width) as f64,
+        }
+    }
+
+    /// Convert the index of a single point in a tile to its lon/lat coordinate.
+    fn coord_to_lonlat(&self, point_coord: geo::Coord) -> Result<crate::projector::LonLatCoord> {
+        #[expect(
+            clippy::cast_precision_loss,
+            clippy::as_conversions,
+            reason = "There's no other way"
+        )]
+        let flipper = self.width as f64 - 1.0f64;
+        let aeqd_coord = geo::coord! {
+            x: (point_coord.x - self.offset) * 100.0f64,
+            y: (flipper - point_coord.y - self.offset) * 100.0f64,
+        };
+        self.projector.to_degrees(aeqd_coord)
+    }
+}
+
+/// Entrypoint.
+pub async fn run(config: &crate::config::LongestLinesOverviews) -> Result<()> {
+    let workers = crate::config::number_of_cpus_on_machine() - 1;
+    let world: StateHash = Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
+
+    let tiffs = find_longest_lines_tiffs_in_path(&config.tiffs)?;
+    let jobs = Arc::new(tokio::sync::RwLock::new(tiffs));
+
+    let mut handles = Vec::new();
+    for worker in 0..workers {
+        let run_id = config.run_id.clone();
+        let world_clone = Arc::clone(&world);
+        let jobs_clone = Arc::clone(&jobs);
+        let handle = tokio::task::spawn(async move {
+            tracing::debug!("Spawning worker {worker}");
+
+            loop {
+                let job = jobs_clone.write().await.pop();
+                match job {
+                    Some(tiff) => {
+                        let result: Result<()> = async {
+                            let local = Tile::process(&tiff)?;
+                            update_state(&world_clone, local, &run_id).await?;
+                            Ok(())
+                        }
+                        .await;
+                        if let Err(error) = result {
+                            tracing::error!("Error running longest lines job: {error}");
+                            #[expect(clippy::exit, reason = "Everything needs to work!")]
+                            std::process::exit(1);
+                        }
+                    }
+                    None => {
+                        tracing::debug!("Worker {worker} shutting down");
+                        break;
+                    }
+                }
+            }
+        });
+
+        handles.push(handle);
+    }
+
+    for result in futures::future::join_all(handles).await {
+        result?;
+    }
+
+    Ok(())
+}
+
+/// Take all the newly found longest lines in a COG and check to see if they're longer than any of
+/// the currently recorded global ones.
+async fn update_state(world: &StateHash, local: HashMap, run_id: &str) -> Result<()> {
+    #[expect(clippy::iter_over_hash_type, reason = "We don't mind about ordering")]
+    for (cell, line) in local {
+        if let Some(existing) = world.write().await.get_mut(&cell) {
+            if line.packed.distance() > existing.packed.distance() {
+                *existing = line;
+            }
+        } else {
+            world.write().await.insert(cell, line);
+        }
+    }
+
+    let mut longest = LongestLine {
+        lonlat: crate::projector::LonLatCoord(geo::Coord::zero()),
+        coord: geo::Coord::zero(),
+        packed: crate::atlas::longest_lines::packed::LineOfSight(0.0),
+    };
+
+    let mut grided = Vec::new();
+    let count = world.read().await.len();
+    #[expect(clippy::iter_over_hash_type, reason = "We don't mind about ordering")]
+    for entry in world.read().await.values() {
+        if entry.packed.distance() > longest.packed.distance() {
+            longest = *entry;
+        }
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::as_conversions,
+            reason = "f32 is enough fidelity. And as long as the cast is consistent, we're good."
+        )]
+        grided.push(super::grided::Grided {
+            lon: entry.lonlat.0.x as f32,
+            lat: entry.lonlat.0.y as f32,
+            distance: entry.packed.distance(),
+        });
+    }
+
+    #[expect(
+        clippy::cast_precision_loss,
+        clippy::as_conversions,
+        reason = "Just for debugging"
+    )]
+    {
+        tracing::info!(
+            "Current longest (out of {count}): {:?} {}km {}° https://alltheviews.world/longest/{},{}",
+            longest.coord,
+            longest.packed.distance() as f32 / 1000.0,
+            longest.packed.angle()?,
+            longest.lonlat.0.x,
+            longest.lonlat.0.y
+        );
+    };
+
+    super::grided::write(
+        format!(
+            "./output/{}",
+            crate::atlas::longest_lines::grided::LONGEST_LINES_GRIDED_FILENAME
+        )
+        .into(),
+        &grided,
+        run_id,
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Find all the `.tiff`s in a given directory.
+fn find_longest_lines_tiffs_in_path(dir: &std::path::Path) -> Result<Vec<std::path::PathBuf>> {
+    let mut files = Vec::new();
+
+    for fallable_entry in std::fs::read_dir(dir)? {
+        let entry = fallable_entry?;
+        let path = entry.path();
+
+        if path.is_file() {
+            let extension = path.extension().and_then(|extension| extension.to_str());
+            if extension == Some("tiff") {
+                files.push(path);
+            }
+        }
+    }
+
+    Ok(files)
+}

--- a/crates/tasks/src/atlas/longest_lines/packed.rs
+++ b/crates/tasks/src/atlas/longest_lines/packed.rs
@@ -1,0 +1,36 @@
+//! Bit packe a longest line's distance and angle into a single `f32`.
+
+/// The max and bitmask for a u22: 4,194,303.
+const U22_MAX: u32 = (1 << 22) - 1;
+/// The max and bitmask for a u10: 1023.
+const U10_MAX: u32 = (1 << 10) - 1;
+
+#[derive(Default, Debug, Clone, Copy)]
+/// Line of sight data that can be packed within 32 bits.
+pub struct LineOfSight(pub f32);
+
+#[expect(
+    clippy::big_endian_bytes,
+    reason = "We don't care about the host's endedness, we're just transmuting"
+)]
+impl LineOfSight {
+    /// Transmute to `u32` in order to do the bitshifting.
+    const fn to_u32(self) -> u32 {
+        u32::from_be_bytes(self.as_f32().to_be_bytes())
+    }
+
+    /// Distance in meters from the point of view to the visible point.
+    pub const fn distance(self) -> u32 {
+        (self.to_u32() >> 10u32) & U22_MAX
+    }
+
+    /// The angle of the line of sight from the point of view.
+    pub fn angle(self) -> color_eyre::Result<u16> {
+        Ok((self.to_u32() & U10_MAX).try_into()?)
+    }
+
+    /// The raw `f32` representation of the packed longest line. Is meaningless unless unpacked.
+    pub const fn as_f32(self) -> f32 {
+        self.0
+    }
+}

--- a/crates/tasks/src/config.rs
+++ b/crates/tasks/src/config.rs
@@ -211,6 +211,10 @@ pub struct LongestLinesOverviews {
     /// Where longest lines COGs are saved.
     #[arg(long, value_name = "Longest lines COGs directory")]
     pub tiffs: std::path::PathBuf,
+
+    /// The ID of the world run.
+    #[arg(long, value_name = "Versioned ID for run")]
+    pub run_id: String,
 }
 
 /// Get the current run's config.
@@ -237,7 +241,7 @@ fn parse_coord(string: &str) -> Result<(f64, f64)> {
 }
 
 /// Get the number of CPUs on the machine.
-fn number_of_cpus_on_machine() -> usize {
+pub fn number_of_cpus_on_machine() -> usize {
     std::fs::read_to_string("/proc/cpuinfo")
         .ok()
         .map(|section| {

--- a/crates/tasks/src/main.rs
+++ b/crates/tasks/src/main.rs
@@ -21,9 +21,12 @@ mod atlas {
     pub mod stitch_all;
     pub mod tile_job;
 
-    // All the code for handling longest lines.
+    /// All the code for handling longest lines.
     pub mod longest_lines {
+        pub mod grided;
         pub mod index;
+        pub mod overview;
+        pub mod packed;
     }
     /// Providers of compute resources.
     pub mod machines {
@@ -96,8 +99,8 @@ async fn main() -> Result<()> {
             config::AtlasCommands::LongestLinesIndex(_) => {
                 atlas::longest_lines::index::compile().await?;
             }
-            config::AtlasCommands::LongestLinesOverviews(_) => {
-                todo!();
+            config::AtlasCommands::LongestLinesOverviews(longest_overviews_config) => {
+                atlas::longest_lines::overview::run(longest_overviews_config).await?;
             }
             config::AtlasCommands::CurrentRunConfig(_) => {
                 atlas::db::print_current_run_config_as_json().await?;

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,6 +1,7 @@
 public/longest_lines
 public/scratch
 public/**/*.tiff
+public/longest_lines_grided.bin
 
 # Local
 .DS_Store

--- a/website/src/renderLongestLine.ts
+++ b/website/src/renderLongestLine.ts
@@ -36,11 +36,7 @@ export function setupLongestLines(coordFromURL: string | undefined) {
     render(event.lngLat);
     const coord = event.lngLat;
 
-    let params = window.location.search;
-    if (window.location.search) {
-      params = `${window.location.search}`;
-    }
-    navigate(`/longest/${coord.lng},${coord.lat}${params}`);
+    navigate(`/longest/${coord.lng},${coord.lat}${window.location.search}`);
   });
 
   if (coordFromURL?.startsWith('longest/')) {
@@ -53,10 +49,11 @@ function extractCoordFromURL(coordFromURL: string) {
   const parts = coordFromURL.replace('longest/', '').split(',');
   const lng = parseFloat(parts[0]);
   const lat = parseFloat(parts[1]);
-  return new LngLat(lng, lat);
+  const coord = new LngLat(lng, lat);
+  return coord;
 }
 
-async function render(lngLat: LngLat) {
+export async function render(lngLat: LngLat) {
   const longest_line = await getLongestLine(lngLat);
   if (longest_line === undefined) {
     return;

--- a/website/src/state.svelte.ts
+++ b/website/src/state.svelte.ts
@@ -1,8 +1,17 @@
 import type { Map as MapLibre } from 'maplibre-gl';
 import type { LongestLine } from './getLongestLine';
+import type { LongestLineH3 } from './worldLines';
 
 let map: MapLibre | undefined;
+let worldLongestLines: LongestLineH3[] | undefined;
 let longestLine: LongestLine | undefined;
+let longestLineInViewport: LongestLineH3 | undefined;
 const isFirstInteraction = false;
 
-export const state = $state({ map, longestLine, isFirstInteraction });
+export const state = $state({
+  map,
+  worldLongestLines,
+  longestLine,
+  longestLineInViewport,
+  isFirstInteraction,
+});

--- a/website/src/utils.ts
+++ b/website/src/utils.ts
@@ -1,11 +1,12 @@
 import { LngLat, LngLatBounds } from 'maplibre-gl';
 
+export const VERSION = '0.1';
 export const CDN_BUCKET = 'https://cdn.alltheviews.world';
 export const MAP_SERVER = 'https://map.alltheviews.world';
 export const WORLD_PMTILES = 'world';
-export const PMTILES_SERVER = `${MAP_SERVER}/runs/0.1/pmtiles/${WORLD_PMTILES}`;
+export const PMTILES_SERVER = `${MAP_SERVER}/runs/${VERSION}/pmtiles/${WORLD_PMTILES}`;
+export const CACHE_BUSTER = '?buster=21:30-17/12/2025';
 
-export const VERSION = '0.1';
 export const EARTH_RADIUS = 6371_000.0;
 
 export const Log = {

--- a/website/src/worldLines.ts
+++ b/website/src/worldLines.ts
@@ -1,0 +1,75 @@
+import { LngLat, type LngLatBounds } from 'maplibre-gl';
+import { state } from './state.svelte';
+import { CACHE_BUSTER, CDN_BUCKET, Log, VERSION } from './utils';
+
+/// The filename for the longest lines grid.
+const LONGEST_LINES_GRIDED_FILENAME = 'longest_lines_grided.bin';
+
+export class LongestLineH3 {
+  coordinate: LngLat;
+  distance: number;
+
+  constructor(coordinate: LngLat, distance: number) {
+    this.coordinate = coordinate;
+    this.distance = distance;
+  }
+
+  toURL() {
+    return `/longest/${this.coordinate.lng},${this.coordinate.lat}${window.location.search}`;
+  }
+
+  toDistance() {
+    const distance = this.distance / 1000;
+    return `${distance}km`;
+  }
+}
+
+async function loadH3Lines() {
+  const indexURL = `${CDN_BUCKET}/runs/${VERSION}/${LONGEST_LINES_GRIDED_FILENAME}${CACHE_BUSTER}`;
+  Log.debug(`Fetching Longest Lines H3 file: ${indexURL}`);
+  const result = await fetch(indexURL);
+
+  if (!result.ok) throw new Error(result.status.toString());
+  const binary = await result.arrayBuffer();
+  const dataView = new DataView(binary);
+
+  const itemSize = 12; // 2*f32 (8 bytes) + u32 (4 bytes)
+  const longestLine: LongestLineH3[] = [];
+  for (
+    let offset = 0;
+    offset + itemSize <= dataView.byteLength;
+    offset += itemSize
+  ) {
+    const x = dataView.getFloat32(offset + 0, true); // little-endian
+    const y = dataView.getFloat32(offset + 4, true);
+    const distance = dataView.getUint32(offset + 8, true);
+    longestLine.push(new LongestLineH3(new LngLat(x, y), distance));
+  }
+
+  longestLine.sort((left, right) => right.distance - left.distance);
+
+  state.worldLongestLines = longestLine;
+}
+
+export async function findLongestLineInBounds(bounds: LngLatBounds) {
+  if (state.worldLongestLines === undefined) {
+    await loadH3Lines();
+  }
+
+  if (state.worldLongestLines === undefined) {
+    return;
+  }
+
+  let max: LongestLineH3 | undefined;
+
+  for (const line of state.worldLongestLines) {
+    if (bounds.contains(line.coordinate)) {
+      if (max === undefined || line.distance > max.distance) {
+        max = line;
+      }
+    }
+  }
+  Log.debug('Found longest line in viewport:', max?.distance);
+
+  return max;
+}


### PR DESCRIPTION
There are probably around 3 billion longest lines of sight that we calculate for the whole world. We don't want to have to query all of those every time a web user lands on the map. So this commit introduces an approach to caching all the longest lines in a grid.

We use Uber's H3 griding system just because the grids are approximately the same area across the whole globe. And there's a good Rust crate for it too. We use resolution level 4, which has around 300k grids for the whole planet. We find the longest line in each of those grids and record it. Hopefully this file remains below ~1Mb for the whole world, so that web users can lazy load it.

TODO:
* [ ] When zoomed in further than the grid resolution, fallback to querying the COG file data that overlaps with the viewport.