### PR TITLE
Move TVS tiff processing out of compute stage

### DIFF
--- a/crates/tasks/src/atlas/tile_job.rs
+++ b/crates/tasks/src/atlas/tile_job.rs
@@ -201,12 +201,6 @@ impl TileRunner<'_> {
         .await?;
 
         if !self.job.config.is_local_run() {
-            // Only heatmap tiffs are created for tiles above Antartica.
-            if self.job.tile.centre.0.y > -80.0f64 {
-                self.s3_put_tvs_tiff().await?;
-            } else {
-                tracing::debug!("Skipping syncing Antartic tile: {:?}", self.job.tile);
-            }
             self.s3_put_raw_tvs_tiff().await?;
         }
 
@@ -236,20 +230,6 @@ impl TileRunner<'_> {
                 ..Default::default()
             })
             .await?;
-
-        Ok(())
-    }
-
-    /// Sync the finished heatmap for the tile to our S3 bucket.
-    async fn s3_put_tvs_tiff(&self) -> Result<()> {
-        let tvs_tiff = self.job.tile.cog_filename();
-        let source = format!("{}/archive/{tvs_tiff}", self.job_directory);
-        let destination = format!(
-            "s3://viewview/runs/{}/tvs/{tvs_tiff}",
-            self.job.config.run_id
-        );
-
-        self.machine.sync_file_to_s3(&source, &destination).await?;
 
         Ok(())
     }

--- a/crates/tasks/src/main.rs
+++ b/crates/tasks/src/main.rs
@@ -32,8 +32,8 @@ mod atlas {
     pub mod machines {
         pub mod cli;
         pub mod connection;
-        pub mod google_cloud;
         pub mod digital_ocean;
+        pub mod google_cloud;
         pub mod local;
         pub mod machine;
         pub mod new_machine_job;

--- a/scripts/cloud_init_ubuntu22.bash
+++ b/scripts/cloud_init_ubuntu22.bash
@@ -13,7 +13,7 @@ function cloud_init_ubuntu22 {
 			libvulkan1 mesa-vulkan-drivers vulkan-tools \
 			build-essential pkg-config \
 			libgdal-dev gdal-bin python3-gdal rsync htop \
-			jq rclone tmux sqlite3
+			jq rclone tmux sqlite3 parallel
 	  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 		echo 'source ~/.cargo/env' >> ~/.bashrc
 		curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/scripts/common.bash
+++ b/scripts/common.bash
@@ -53,3 +53,13 @@ function _uvx {
 		~/.local/bin/uvx "$@"
 	fi
 }
+
+function get_tiff_longitude {
+	local input=$1
+	gdalinfo -json "$input" | jq '.geoTransform[0]'
+}
+
+function get_tiff_latitude {
+	local input=$1
+	gdalinfo -json "$input" | jq '.geoTransform[3]'
+}

--- a/scripts/make_pmtiles.bash
+++ b/scripts/make_pmtiles.bash
@@ -25,13 +25,13 @@ function make_pmtiles {
 	gdalbuildvrt "$world_vrt" "$archive"/*.tiff
 
 	# Create overviews to speed up tile creation at lower zoom levels.
-	# Note: Compression would be good, but I've seen it cause segfaults.
+	# Notes:
+	#  * Compression would be good, but I've seen it cause segfaults.
+	#  * I tried to `parallel` this, but not only is not faster but the final overviews aren't
+	#    usable by our pmtiler.
 	gdaladdo \
 		-r bilinear \
-		--config BIGTIFF YES \
-		--config GDAL_NUM_THREADS ALL_CPUS \
-		"$world_vrt" \
-		2 4 8 16 32 64 128 256
+		"$world_vrt" 2 4 8 16 32 64 128 256
 
 	# Create the global `.pmtile`
 	uv run scripts/to_pmtiles.py "$world_vrt" "$output" \
@@ -41,4 +41,57 @@ function make_pmtiles {
 	if [[ $version != "local" ]]; then
 		rclone_put "$output" viewview/runs/"$version"/pmtiles/
 	fi
+}
+
+# Interpolate the TVS heatmap's data to EPSG:3857.
+#
+# Along with all the other heatmap GeoTiff's, it will be used to create the single global
+# `.pmtile`. EPSG:3857 is the Mercator metric projection, it is better for tiling.
+#
+# Note: We need to force the pixel size because without it then `gdal` chooses bad sizes. It
+# makes tiles at the poles, for example, start reaching pixel sizes of ~500. That worst case
+# is then used as the default for the _whole_ world!
+#
+# TODO: Use worker jobs to parallelise. Will speed it up and give retries and resumes.
+function reproject_raw_tvs_tiff {
+	local input=$1
+	local output=$2
+
+	# EPSG:3857 but allowing wrapping over ±180°
+	wrapping_web_mercator="\
+	  +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0 \
+    +over +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null \
+    +wktext +lon_wrap=-180 +no_defs\
+	"
+	latitude=$(echo "$input" | sed -E 's#.*_([0-9.-]+)\.tiff#\1#')
+
+	if (($(echo "$latitude > -80" | bc -l))); then
+		gdalwarp \
+			-overwrite \
+			-tr 100 100 \
+			-t_srs "$wrapping_web_mercator" \
+			-dstnodata 0 \
+			-srcnodata 0 \
+			-r bilinear \
+			-co BIGTIFF=IF_SAFER \
+			-co COMPRESS=DEFLATE \
+			-co TILED=YES \
+			-co PREDICTOR=3 \
+			"$input" "$output"
+	else
+		echo "Not creating TVS heatmap tiff for Antartic tile: $input"
+	fi
+}
+
+function reproject_raw_tvs_tiffs {
+	local source=$1
+	local destination=$2
+
+	mkdir -p "$destination"
+
+	for path in "$source"/*.tiff; do
+		[[ -f $path ]] || continue
+		file=$(basename "$path")
+		reproject_raw_tvs_tiff "$path" "$destination/$file"
+	done
 }

--- a/scripts/s3.bash
+++ b/scripts/s3.bash
@@ -79,5 +79,5 @@ function get_s3_folder {
 function download_all_tvs_tiffs {
 	local version=$1
 
-	get_s3_folder viewview/runs/"$version"/tvs work/local/archive
+	get_s3_folder viewview/runs/"$version"/raw work/raw
 }


### PR DESCRIPTION
It's better to use dedicated machines for compute and post-processing. Also it's just good to have the post-processing completely isolated so that we don't have to redo a compute run just to render the global .pmtile.