### PR TITLE
Find longest lines in the viewport at high zooms

### DIFF
--- a/website/src/getLongestLine.ts
+++ b/website/src/getLongestLine.ts
@@ -1,12 +1,13 @@
 import nprogress from 'accessible-nprogress';
 import type { GeoTIFFImage } from 'geotiff';
 import { fromUrl as geotiffFromURL } from 'geotiff';
-import { LngLat } from 'maplibre-gl';
+import { LngLat, type LngLatBounds } from 'maplibre-gl';
 import proj4 from 'proj4';
 import {
   aeqdProjectionString,
   CACHE_BUSTER,
   CDN_BUCKET,
+  clamp,
   Log,
   VERSION,
 } from './utils';
@@ -22,7 +23,7 @@ export type LongestLine = {
   to: LngLat;
 };
 
-type Index = {
+type IndexedTile = {
   centre: LngLat;
   width: number;
 };
@@ -30,7 +31,7 @@ type Index = {
 // Source of the longest lines COGs.
 const LONGEST_LINES_COGS = getLongestLinesSource();
 // Contents of index of Longest Lines COGs.
-const cogsIndex: Map<string, Index> = new Map();
+const cogsIndex: Map<string, IndexedTile> = new Map();
 // Our local cache of COG files.
 const cogs: Map<string, GeoTIFFImage> = new Map();
 
@@ -61,8 +62,8 @@ export async function getLongestLine(coordinate: LngLat) {
 }
 
 async function getLongestLines(coordinate: LngLat) {
-  const urls = await findNearestCOGURLs(coordinate);
-  if (urls.length === 0) {
+  const cogFilenames = await findNearestCOGURLs(coordinate);
+  if (cogFilenames.length === 0) {
     console.warn(
       `${coordinate} is not within the radius of any Longest Line COGs`,
     );
@@ -70,8 +71,8 @@ async function getLongestLines(coordinate: LngLat) {
   }
 
   const candidates: LongestLine[] = [];
-  for (const url of urls) {
-    const cog = await getCOG(url);
+  for (const filename of cogFilenames) {
+    const cog = await getCOG(filename);
     if (cog === undefined) {
       continue;
     }
@@ -85,18 +86,31 @@ async function getLongestLines(coordinate: LngLat) {
 }
 
 async function getLongestLineCandidate(cog: GeoTIFFImage, coordinate: LngLat) {
-  const result = getPointCoordinate(cog, coordinate);
-  if (result === undefined) {
+  const { x_point, y_point } = convertLngLatToRasterXY(cog, coordinate);
+  // TODO: update this to check outside the _circle_ of the tile?
+  if (
+    x_point < 0 ||
+    y_point < 0 ||
+    x_point >= cog.getWidth() ||
+    y_point >= cog.getHeight()
+  ) {
+    console.warn(
+      `Clicked point ${x_point}/${y_point} is out of bounds ${cog.getWidth()}x${cog.getHeight()}`,
+    );
     return;
   }
-  const { x_point, y_point } = result;
-  const flipper = cog.getWidth() - 1.0;
-  const y_flipped = flipper - y_point;
-
-  const { distance, angle } = await getPointFromRaster(cog, x_point, y_flipped);
 
   Log.debug('clicked at', coordinate);
-  Log.debug('coordinate in raster', [x_point, y_flipped]);
+  Log.debug('coordinate in raster', [x_point, y_point]);
+
+  const max = await getPointFromRaster(cog, x_point, y_point);
+  if (max === undefined) {
+    Log.debug("Couldn't find longest line at clicked point");
+    return;
+  }
+
+  const { distance, angle } = max;
+
   Log.debug('distance:', distance, u32BitsToString(distance));
   Log.debug('angle:', angle, u32BitsToString(angle));
 
@@ -112,28 +126,48 @@ async function getPointFromRaster(cog: GeoTIFFImage, x: number, y: number) {
   // We need to find the longest line in a 5x5 grid to get around precision loss.
   const around = 2;
 
-  const raster = (await cog.readRasters({
-    window: [x - around, y - around, x + around, y + around],
-    width: around * 2 + 1,
-    height: around * 2 + 1,
-  })) as Float32Array[];
+  const extent = [x - around, y - around, x + around, y + around];
 
-  let max = { distance: 0, angle: 0 };
-  for (const row of raster) {
-    for (const packed of row) {
-      const packed_u32 = f32ToU32(packed);
-      const distance = (packed_u32 >>> 10) & U22_MASK;
-      const angle = packed_u32 & U10_MASK;
-      if (distance > max.distance) {
-        max = { distance, angle };
-      }
+  const max = findLongestInWindow(cog, extent);
+  return max;
+}
+
+export async function findLongestInWindow(cog: GeoTIFFImage, window: number[]) {
+  Log.debug(
+    `Raster size: ${cog.getWidth()}x${cog.getHeight()}.`,
+    'Fetching data from raster using window:',
+    window,
+  );
+  const raster = (await cog.readRasters({
+    window,
+  })) as Float32Array[];
+  const packedLines = raster[0];
+
+  const windowOriginX = window[0];
+  const windowOriginY = window[1];
+  const width = window[2] - window[0];
+
+  let max:
+    | { distance: number; angle: number; x: number; y: number }
+    | undefined;
+  let index = 0;
+  for (const packedLine of packedLines) {
+    const packed_u32 = f32ToU32(packedLine);
+    const distance = (packed_u32 >>> 10) & U22_MASK;
+    const angle = packed_u32 & U10_MASK;
+    if (max === undefined || distance > max.distance) {
+      const x = windowOriginX + Math.floor(index / width);
+      const y = windowOriginY + (index % width);
+      max = { distance, angle, x, y };
     }
+    index += 1;
   }
 
   return max;
 }
 
-async function getCOG(url: string) {
+async function getCOG(filename: string) {
+  const url = `${LONGEST_LINES_COGS}/${filename}`;
   let cog = cogs.get(url);
 
   if (cog === undefined) {
@@ -146,34 +180,39 @@ async function getCOG(url: string) {
   return cog;
 }
 
-async function findNearestCOGURLs(coordinate: LngLat) {
+async function ensureLongestLinesIndexLoaded() {
+  if (cogsIndex.size > 0) {
+    return;
+  }
   const indexURL = `${LONGEST_LINES_COGS}/index.txt${CACHE_BUSTER}`;
-  if (cogsIndex.size === 0) {
-    Log.debug(`Fetching Longest Line COGs file: ${indexURL}`);
+  Log.debug(`Fetching Longest Line COGs file: ${indexURL}`);
 
-    const result = await fetch(indexURL);
-    if (!result.ok) throw new Error(result.status.toString());
-    const contents = await result.text();
+  const result = await fetch(indexURL);
+  if (!result.ok) throw new Error(result.status.toString());
+  const contents = await result.text();
 
-    for (const line of contents.split('\n')) {
-      const lineParts = line.split(' ');
-      if (lineParts.length !== 2) {
-        continue;
-      }
-      const filename = lineParts[0];
-      const lonLatParts = filename.replace('.tiff', '').split('_');
-      const centre = new LngLat(
-        parseFloat(lonLatParts[0]),
-        parseFloat(lonLatParts[1]),
-      );
-      const width = parseInt(lineParts[1], 10);
-      cogsIndex.set(filename, { centre, width });
+  for (const line of contents.split('\n')) {
+    const lineParts = line.split(' ');
+    if (lineParts.length !== 2) {
+      continue;
     }
+    const filename = lineParts[0];
+    const lonLatParts = filename.replace('.tiff', '').split('_');
+    const centre = new LngLat(
+      parseFloat(lonLatParts[0]),
+      parseFloat(lonLatParts[1]),
+    );
+    const width = parseInt(lineParts[1], 10);
+    cogsIndex.set(filename, { centre, width });
   }
 
   Log.debug('Longest Lines index', cogsIndex);
+}
 
-  const urls = [];
+async function findNearestCOGURLs(coordinate: LngLat) {
+  await ensureLongestLinesIndexLoaded();
+
+  const cogFilenames = [];
   for (const [filename, cog] of cogsIndex) {
     const distance = coordinate.distanceTo(cog.centre);
     const scale = 100; // TODO: I thought we decided to set this in the indexer?
@@ -184,46 +223,103 @@ async function findNearestCOGURLs(coordinate: LngLat) {
       `Distance from click: ${distance}`,
     );
     if (distance < radius) {
-      urls.push(`${LONGEST_LINES_COGS}/${filename}`);
-      Log.debug(`✅ Longest Line COG found: ${urls}`);
+      cogFilenames.push(filename);
+      Log.debug(`✅ Longest Line COG found: ${cogFilenames}`);
     }
   }
 
-  return urls;
+  return cogFilenames;
+}
+
+export async function findTilesIntersectingViewport(
+  viewportBounds: LngLatBounds,
+) {
+  await ensureLongestLinesIndexLoaded();
+  const cogsNearby = [];
+  for (const [filename, tile] of cogsIndex) {
+    if (isTileIntersectingViewport(tile, viewportBounds)) {
+      Log.debug('Viewport-intersecting tile found:', tile);
+      const cog = await getCOG(filename);
+      cogsNearby.push(cog);
+    }
+  }
+  return cogsNearby;
+}
+
+function isTileIntersectingViewport(
+  tile: IndexedTile,
+  viewportBounds: LngLatBounds,
+) {
+  // TODO: why divide by 100?? The width is already in metres right?? And the distance calculation
+  // is in meters, so..?
+  const radius = tile.width / 2.0 / 100.0;
+
+  // Closest point on square to circle center
+  const closestX = clamp(
+    tile.centre.lng,
+    viewportBounds.getSouthWest().lng,
+    viewportBounds.getSouthEast().lng,
+  );
+  const closestY = clamp(
+    tile.centre.lat,
+    viewportBounds.getSouthWest().lat,
+    viewportBounds.getNorthWest().lat,
+  );
+
+  // Squared distance from circle center to that point
+  const distance = tile.centre.distanceTo(new LngLat(closestX, closestY));
+  const distanceSquared = distance * distance;
+
+  return distanceSquared <= radius * radius;
 }
 
 // Convert lon/lat to COG-relative point.
-function getPointCoordinate(image: GeoTIFFImage, coordinate: LngLat) {
-  const geo = image.getGeoKeys();
+export function convertLngLatToRasterXY(cog: GeoTIFFImage, coordinate: LngLat) {
+  const geo = cog.getGeoKeys();
   const projection = aeqdProjectionString(
     geo.ProjCenterLongGeoKey,
     geo.ProjCenterLatGeoKey,
   );
-  const resolution = image.getResolution();
+  const resolution = cog.getResolution();
+  const maxIndex = cog.getWidth() - 1.0;
 
   const [x_metres, y_metres] = proj4(proj4.WGS84, projection, [
     coordinate.lng,
     coordinate.lat,
   ]);
-  const offset = image.getWidth() / 2.0;
+  const offset = maxIndex / 2.0;
   const scale = Math.abs(resolution[0]);
-  const x_point = Math.floor(x_metres / scale) + offset;
-  const y_point = Math.floor(y_metres / scale) + offset;
-
-  // TODO: update this to check outside the circle of the tile?
-  if (
-    x_point < 0 ||
-    y_point < 0 ||
-    x_point >= image.getWidth() ||
-    y_point >= image.getHeight()
-  ) {
-    console.warn(
-      `Clicked point ${x_point}/${y_point} is out of bounds ${image.getWidth()}x${image.getHeight()}`,
-    );
-    return;
-  }
+  const x_unclamped = Math.floor(x_metres / scale + offset);
+  const y_unclamped = Math.floor(y_metres / scale + offset);
+  const x_point = clamp(x_unclamped, 0, maxIndex);
+  const y_point = maxIndex - clamp(y_unclamped, 0, maxIndex);
 
   return { x_point, y_point };
+}
+
+// Convert a raster's x,y pixel coordinate to long/lat.
+export function convertRasterXYToLngLat(
+  cog: GeoTIFFImage,
+  x: number,
+  y: number,
+) {
+  const geo = cog.getGeoKeys();
+  const projection = aeqdProjectionString(
+    geo.ProjCenterLongGeoKey,
+    geo.ProjCenterLatGeoKey,
+  );
+  const resolution = cog.getResolution();
+  const scale = Math.abs(resolution[0]);
+  const maxIndex = cog.getWidth() - 1.0;
+  const offset = maxIndex / 2.0;
+  const y_flipped = maxIndex - y;
+
+  const x_metric = (x - offset) * scale;
+  const y_metric = (y_flipped - offset) * scale;
+  const [lng, lat] = proj4(projection, proj4.WGS84, [x_metric, y_metric]);
+  console.log(x, y, x_metric, y_metric, lng, lat);
+
+  return new LngLat(lng, lat);
 }
 
 function getLongestLinesSource() {

--- a/website/src/utils.ts
+++ b/website/src/utils.ts
@@ -5,6 +5,9 @@ export const CDN_BUCKET = 'https://cdn.alltheviews.world';
 export const MAP_SERVER = 'https://map.alltheviews.world';
 export const WORLD_PMTILES = 'world';
 export const PMTILES_SERVER = `${MAP_SERVER}/runs/${VERSION}/pmtiles/${WORLD_PMTILES}`;
+
+// This is for busting Cloudflare asset cache. Like for an updated `world.pmtiles`,
+// longest lines index, etc.
 export const CACHE_BUSTER = '?buster=08:51-10/01/2026';
 
 export const EARTH_RADIUS = 6371_000.0;
@@ -110,4 +113,8 @@ export function computeBBox(coordinates: number[][]) {
   }
 
   return new LngLatBounds([minLng, minLat, maxLng, maxLat]);
+}
+
+export function clamp(value: number, lowerBound: number, upperBound: number) {
+  return Math.max(lowerBound, Math.min(upperBound, value));
 }


### PR DESCRIPTION
The longest lines grid has grids approx 50km wide, so it's possible that when you're zoomed in you find yourself in between the longest line of each grid. So instead we have to just brute force our way through all the tiles that overlap the viewport and iterate through their intersecting raster data.