### PR TITLE
requeue jobs on restart, shutdown worker that errors out

### DIFF
--- a/crates/tasks/src/atlas/machines/worker.rs
+++ b/crates/tasks/src/atlas/machines/worker.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, OnceLock};
 use crate::atlas::machines::connection::Connection;
 use crate::atlas::tile_job::{TileJob, TileWorkerState, WORKING_DIRECTORY};
 use apalis::layers::WorkerBuilderExt as _;
+use apalis::prelude::WorkerBuilder;
 use color_eyre::Result;
 use tokio::sync::Mutex;
 
@@ -73,7 +74,8 @@ pub async fn tile_processor(
     // Computation concurrency is effectively 1 due to mutex locking in the tile job.
     let worker_concurrency = 2;
 
-    apalis::prelude::WorkerBuilder::new(tile_worker_name.clone())
+
+    WorkerBuilder::new(tile_worker_name.clone())
         .backend(tile_store)
         .data(Arc::new(state))
         .concurrency(worker_concurrency)

--- a/crates/tasks/src/config.rs
+++ b/crates/tasks/src/config.rs
@@ -287,3 +287,4 @@ pub fn number_of_cpus_on_machine() -> usize {
         .filter(|cpu| *cpu > 0)
         .unwrap_or(1)
 }
+

--- a/scripts/atlas.bash
+++ b/scripts/atlas.bash
@@ -85,6 +85,20 @@ function restart_failed_jobs {
 	"
 }
 
+function requeue_running {
+	atlas_query "
+    UPDATE Jobs SET
+      status = 'Pending',
+      run_at = strftime('%s', 'now'),
+      lock_at = NULL,
+      lock_by = NULL,
+      done_at = NULL,
+      last_result = NULL,
+      attempts = 0
+    WHERE status='Running'
+	"
+}
+
 function rebalance_queue {
 	atlas_query "
 	  UPDATE Jobs SET
@@ -97,4 +111,10 @@ function rebalance_queue {
 			attempts = 0
     WHERE status='Queued'
 	"
+}
+
+function replay_last_run {
+  requeue_running
+  rebalance_queue
+  restart_failed_jobs
 }

--- a/scripts/google_cloud.bash
+++ b/scripts/google_cloud.bash
@@ -3,7 +3,7 @@
 
 function spin_google_cloud {
   gcloud compute instances create "$1" --format="json" \
-      --zone=us-central1-c \
+      --zone=us-central1-a \
       --machine-type=c4d-highcpu-96 \
       --network-interface=network-tier=PREMIUM,nic-type=GVNIC,stack-type=IPV4_ONLY,subnet=default \
       --metadata=startup-script="sudo rm -r /usr/lib/google-cloud-sdk/",ssh-keys=atlas:"$2" \

--- a/scripts/world_run.bash
+++ b/scripts/world_run.bash
@@ -6,6 +6,11 @@ function provision_gcloud {
 function run_worker {
     eval "$(ssh-agent)"
     ssh-add ~/.ssh/id_rsa
+
+    if [ -e "state/atlas.db" ]; then
+      replay_last_run
+    fi
+
     RUST_LOG=info,axum=trace,apalis=trace,tasks=trace cargo run --release --bin tasks -- atlas worker
 }
 


### PR DESCRIPTION
Most worker errors from Google Cloud come from when the spot instance is shutdown, which is a catastrophic failure for Atlas. This shuts down a worker at any failure to minimize the blast radius and allow for Atlas to continue queueing jobs.

When Atlas is shutdown or restarted, it also leaves a large chunk of running and already failed jobs out of the queue, so the `run_worker` ctl command now makes sure that all pending, failed, or killed jobs are requeued