### PR TITLE
Add RTL langs support in map text-field

### DIFF
--- a/website/src/Home.svelte
+++ b/website/src/Home.svelte
@@ -12,6 +12,7 @@
     Map as MapLibre,
     NavigationControl,
     type StyleSpecification,
+    setRTLTextPlugin,
   } from 'maplibre-gl';
   import { onMount } from 'svelte';
   import { navigate } from 'svelte5-router';
@@ -106,7 +107,7 @@
     state.longestLineInViewport = await findLongestLineInBoundsFromGrid(bounds);
   }
 
-  onMount(() => {
+  onMount(async () => {
     state.map = new MapLibre({
       container: 'map',
       zoom: startingZoom,
@@ -123,6 +124,13 @@
       'bottom-right',
     );
 
+    // https://maplibre.org/maplibre-gl-js/docs/API/functions/setRTLTextPlugin/
+    if (typeof window !== 'undefined') {
+      await setRTLTextPlugin(
+        'https://unpkg.com/@mapbox/mapbox-gl-rtl-text@0.3.0/dist/mapbox-gl-rtl-text.js',
+        true,
+      );
+    }
     state.map.on('load', async () => {
       initClickEffect();
       if (longest === '') {


### PR DESCRIPTION
Set the MapLibre RTL plugin to [mapbox-gl-rtl-text](https://www.npmjs.com/package/@mapbox/mapbox-gl-rtl-text) via maplibre-gl's `setRTLTextPlugin(pluginURL: string, lazy: boolean)`

This allows text-field values in Arabic or Hebrew to propagate in the correct direction.

Before:
<img width="444" height="264" alt="Screenshot 2026-02-06 at 12 46 25 PM" src="https://github.com/user-attachments/assets/73e03a80-f20d-4d06-8826-c021bdecda34" />

After:
<img width="444" height="264" alt="Screenshot 2026-02-06 at 12 46 38 PM" src="https://github.com/user-attachments/assets/e47ab246-e7c2-4002-a838-17e0b4576a59" />