### PR TITLE
New mobile-only layout

### DIFF
--- a/website/src/Home.svelte
+++ b/website/src/Home.svelte
@@ -360,6 +360,34 @@
 		gap: 1em;
 	}
 
+	/* Mobile-only layout tweaks */
+	@media (max-width: 600px) {
+		/* slightly smaller collapsed modal icons on Home only */
+		:global(#info .collapseable_modal .modal__open svg) {
+			width: 1rem;
+			height: 1rem;
+		}
+
+		/* align top of first info button roughly with search bar */
+		#info {
+			top: 1.08rem;
+			right: 0.75rem;
+			max-width: min(22rem, 80vw);
+			gap: 0.75rem;
+		}
+
+		:global(#info .collapseable_modal > div) {
+			padding: 0.75em;
+		}
+
+		#layout_toggles {
+			left: 0.5rem;
+			bottom: 0.5rem;
+			gap: 0.4rem;
+			flex-direction: column;
+		}
+	}
+
 	.unclickable_icon {
 		display: inline-block;
 		scale: 0.7;

--- a/website/src/Home.svelte
+++ b/website/src/Home.svelte
@@ -330,7 +330,8 @@
 	</div>
 </Layout>
 
-<style>
+<style lang="scss">
+	@use "./styles/variables.scss" as *;
 	#info {
 		position: fixed;
 		top: 1em;
@@ -361,7 +362,7 @@
 	}
 
 	/* Mobile-only layout tweaks */
-	@media (max-width: 600px) {
+	@media (max-width: $mobile-break) {
 		/* slightly smaller collapsed modal icons on Home only */
 		:global(#info .collapseable_modal .modal__open svg) {
 			width: 1rem;

--- a/website/src/Home.svelte
+++ b/website/src/Home.svelte
@@ -170,7 +170,16 @@
 <Layout>
 	<ClickEffect />
 	<div id="info">
-		<CollapsableModal collapsedIcon={Info} isOpen={!state.isFirstInteraction}>
+		<CollapsableModal collapsedIcon={Info}
+		isOpen={state.isInfoOpen}
+		on:open={() => {
+			state.isSearchOpen = false;
+			state.isInfoOpen = true;
+		}}
+		on:close={() => {
+			state.isInfoOpen = false;
+		}}
+	>
 			<h2>All The Views In The World</h2>
 			<p>We've calculated all the views on the planet.</p>
 			<p>

--- a/website/src/Home.svelte
+++ b/website/src/Home.svelte
@@ -171,15 +171,15 @@
 	<ClickEffect />
 	<div id="info">
 		<CollapsableModal collapsedIcon={Info}
-		isOpen={state.isInfoOpen}
-		on:open={() => {
-			state.isSearchOpen = false;
-			state.isInfoOpen = true;
-		}}
-		on:close={() => {
-			state.isInfoOpen = false;
-		}}
-	>
+			isOpen={state.isInfoOpen}
+			onOpen={() => {
+				state.isSearchOpen = false;
+				state.isInfoOpen = true;
+			}}
+			onClose={() => {
+				state.isInfoOpen = false;
+			}}
+		>
 			<h2>All The Views In The World</h2>
 			<p>We've calculated all the views on the planet.</p>
 			<p>

--- a/website/src/Layout.svelte
+++ b/website/src/Layout.svelte
@@ -2,8 +2,8 @@
   import { onDestroy } from 'svelte';
   import 'maplibre-gl/dist/maplibre-gl.css';
   import 'accessible-nprogress/src/styles.css';
-  import { state } from './state.svelte.ts';
   import SearchBox from './components/SearchBox.svelte';
+  import { state } from './state.svelte.ts';
 
   onDestroy(() => {
     state.map?.remove();

--- a/website/src/Layout.svelte
+++ b/website/src/Layout.svelte
@@ -26,8 +26,13 @@
       disablePointer();
     });
 
-    // @ts-expect-error: `document` can't be null.
-    document.querySelector('#search-box').appendChild(searchBox);
+    /* #search-widget is hidden (display: none) on mobile until the user expands search;
+    we still mount here so the box is ready. Guard in case the node isn't available yet. */
+    const container = document.querySelector('#search-widget');
+    if (container) {
+      // @ts-expect-error: MapboxSearchBox is a custom element
+      container.appendChild(searchBox);
+    }
   });
 
   onDestroy(() => {

--- a/website/src/Layout.svelte
+++ b/website/src/Layout.svelte
@@ -2,10 +2,7 @@
   import { onDestroy, onMount } from 'svelte';
   import 'maplibre-gl/dist/maplibre-gl.css';
   import 'accessible-nprogress/src/styles.css';
-<<<<<<< HEAD
-=======
   import { Search } from '@lucide/svelte';
->>>>>>> af3023c (satisfy biome lint for CollapsableModal dispatcher & import reordering)
   import { MapboxSearchBox } from '@mapbox/search-js-web';
   import { state } from './state.svelte.ts';
   import { disablePointer } from './utils.ts';
@@ -46,7 +43,19 @@
 
 <div id="map"></div>
 
-<div id="search-box"></div>
+<div id="search-box" class:is-open={state.isSearchOpen}>
+	<div id="search-widget"></div>
+	<button
+		id="search-toggle"
+		type="button"
+		on:click={() => {
+			state.isSearchOpen = true;
+			state.isInfoOpen = false;
+		}}
+	>
+		<Search size={18} />
+	</button>
+</div>
 
 <main>
 	<slot />
@@ -65,4 +74,61 @@
 		margin-left: 17px;
 		margin-top: 17px;
 	}
+  
+	#search-widget {
+		width: 100%;
+	}
+
+	#search-toggle {
+		all: unset;
+		cursor: pointer;
+		display: none;
+	}
+
+	/* Mobile: search behaves like a compact icon button that expands into the full input */
+	@media (max-width: 600px) {
+		#search-box {
+			width: 2.75rem;
+			height: 2.5rem;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			overflow: hidden;
+			background-color: white;
+			border-radius: 3px;
+			z-index: 2;
+		}
+
+		#search-toggle {
+			display: flex;
+			width: 1rem;
+			height: 2.5rem;
+			align-items: center;
+			justify-content: center;
+			color: #141f41;
+		}
+
+		/* collapsed: only icon button visible */
+		#search-widget {
+			display: none;
+		}
+
+		/* expanded: show full widget, hide icon, grow container */
+		#search-box.is-open {
+			width: min(18rem, 80vw);
+			height: auto;
+			overflow: visible;
+			background-color: transparent;
+			border-radius: 0;
+		}
+
+		#search-box.is-open #search-widget {
+			display: block;
+		}
+
+		#search-box.is-open #search-toggle {
+			display: none;
+		}
+	}
+
 </style>

--- a/website/src/Layout.svelte
+++ b/website/src/Layout.svelte
@@ -1,40 +1,9 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy } from 'svelte';
   import 'maplibre-gl/dist/maplibre-gl.css';
   import 'accessible-nprogress/src/styles.css';
-  import { Search } from '@lucide/svelte';
-  import { MapboxSearchBox } from '@mapbox/search-js-web';
   import { state } from './state.svelte.ts';
-  import { disablePointer } from './utils.ts';
-
-  onMount(() => {
-    const searchBox = new MapboxSearchBox();
-    searchBox.accessToken =
-      'pk.eyJ1IjoidG9tYmgiLCJhIjoiY2p4cWlqNnY1MDFhZDNscXc5YXJpcTJzciJ9.7gGR5t8KEAY0ZoXfTVBcng';
-    searchBox.options = {
-      types: 'poi,place,country',
-      poi_category: 'mountain,natural_feature',
-    };
-    searchBox.addEventListener('retrieve', (e) => {
-      const feature = e.detail;
-      const coordinates = feature.features[0]?.geometry.coordinates;
-      state.map?.flyTo({
-        center: [coordinates[0], coordinates[1]],
-        zoom: 11,
-      });
-      state.isFlying = true;
-
-      disablePointer();
-    });
-
-    /* #search-widget is hidden (display: none) on mobile until the user expands search;
-    we still mount here so the box is ready. Guard in case the node isn't available yet. */
-    const container = document.querySelector('#search-widget');
-    if (container) {
-      // @ts-expect-error: MapboxSearchBox is a custom element
-      container.appendChild(searchBox);
-    }
-  });
+  import SearchBox from './components/SearchBox.svelte';
 
   onDestroy(() => {
     state.map?.remove();
@@ -43,19 +12,7 @@
 
 <div id="map"></div>
 
-<div id="search-box" class:is-open={state.isSearchOpen}>
-	<div id="search-widget"></div>
-	<button
-		id="search-toggle"
-		type="button"
-		on:click={() => {
-			state.isSearchOpen = true;
-			state.isInfoOpen = false;
-		}}
-	>
-		<Search size={18} />
-	</button>
-</div>
+<SearchBox />
 
 <main>
 	<slot />
@@ -67,68 +24,4 @@
 		height: 100%;
 		width: 100%;
 	}
-
-	#search-box {
-		position: absolute;
-		width: 300px;
-		margin-left: 17px;
-		margin-top: 17px;
-	}
-  
-	#search-widget {
-		width: 100%;
-	}
-
-	#search-toggle {
-		all: unset;
-		cursor: pointer;
-		display: none;
-	}
-
-	/* Mobile: search behaves like a compact icon button that expands into the full input */
-	@media (max-width: 600px) {
-		#search-box {
-			width: 2.75rem;
-			height: 2.5rem;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			overflow: hidden;
-			background-color: white;
-			border-radius: 3px;
-			z-index: 2;
-		}
-
-		#search-toggle {
-			display: flex;
-			width: 1rem;
-			height: 2.5rem;
-			align-items: center;
-			justify-content: center;
-			color: #141f41;
-		}
-
-		/* collapsed: only icon button visible */
-		#search-widget {
-			display: none;
-		}
-
-		/* expanded: show full widget, hide icon, grow container */
-		#search-box.is-open {
-			width: min(18rem, 80vw);
-			height: auto;
-			overflow: visible;
-			background-color: transparent;
-			border-radius: 0;
-		}
-
-		#search-box.is-open #search-widget {
-			display: block;
-		}
-
-		#search-box.is-open #search-toggle {
-			display: none;
-		}
-	}
-
 </style>

--- a/website/src/Layout.svelte
+++ b/website/src/Layout.svelte
@@ -2,6 +2,10 @@
   import { onDestroy, onMount } from 'svelte';
   import 'maplibre-gl/dist/maplibre-gl.css';
   import 'accessible-nprogress/src/styles.css';
+<<<<<<< HEAD
+=======
+  import { Search } from '@lucide/svelte';
+>>>>>>> af3023c (satisfy biome lint for CollapsableModal dispatcher & import reordering)
   import { MapboxSearchBox } from '@mapbox/search-js-web';
   import { state } from './state.svelte.ts';
   import { disablePointer } from './utils.ts';

--- a/website/src/components/CollapsableModal.svelte
+++ b/website/src/components/CollapsableModal.svelte
@@ -1,21 +1,35 @@
 <script lang="ts">
   import { Minimize2 } from '@lucide/svelte';
   import type { Component } from 'svelte';
+  import { createEventDispatcher } from 'svelte';
 
   export let collapsedIcon: Component;
   export let isOpen = true;
   const __buttonSize = 18;
+  const _dispatch = createEventDispatcher();
 </script>
 
 <div class="collapseable_modal {isOpen ? '' : 'modal__collapsed'}">
 	<div>
 		{#if isOpen}
-			<button class="modal__close" on:click={() => (isOpen = false)}>
+			<button
+				class="modal__close"
+				on:click={() => {
+					isOpen = false;
+					_dispatch('close');
+				}}
+			>
 				<Minimize2 size={__buttonSize} />
 			</button>
 			<slot />
 		{:else}
-			<button class="modal__open" on:click={() => (isOpen = true)}>
+			<button
+				class="modal__open"
+				on:click={() => {
+					isOpen = true;
+					_dispatch('open');
+				}}
+			>
 				<svelte:component this={collapsedIcon} size={__buttonSize} />
 			</button>
 		{/if}

--- a/website/src/components/CollapsableModal.svelte
+++ b/website/src/components/CollapsableModal.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { Minimize2 } from '@lucide/svelte';
   import type { Component } from 'svelte';
-  import { createEventDispatcher } from 'svelte';
 
   export let collapsedIcon: Component;
   export let isOpen = true;
+  export let onOpen: (() => void) | undefined;
+  export let onClose: (() => void) | undefined;
   const __buttonSize = 18;
-  const dispatch = createEventDispatcher();
 </script>
 
 <div class="collapseable_modal {isOpen ? '' : 'modal__collapsed'}">
@@ -16,7 +16,7 @@
 				class="modal__close"
 				on:click={() => {
 					isOpen = false;
-					dispatch('close');
+					onClose?.();
 				}}
 			>
 				<Minimize2 size={__buttonSize} />
@@ -27,7 +27,7 @@
 				class="modal__open"
 				on:click={() => {
 					isOpen = true;
-					dispatch('open');
+					onOpen?.();
 				}}
 			>
 				<svelte:component this={collapsedIcon} size={__buttonSize} />

--- a/website/src/components/CollapsableModal.svelte
+++ b/website/src/components/CollapsableModal.svelte
@@ -4,8 +4,8 @@
 
   export let collapsedIcon: Component;
   export let isOpen = true;
-  export let onOpen: (() => void) | undefined;
-  export let onClose: (() => void) | undefined;
+  export let onOpen: (() => void) | undefined = undefined;
+  export let onClose: (() => void) | undefined = undefined;
   const __buttonSize = 18;
 </script>
 

--- a/website/src/components/CollapsableModal.svelte
+++ b/website/src/components/CollapsableModal.svelte
@@ -6,7 +6,7 @@
   export let collapsedIcon: Component;
   export let isOpen = true;
   const __buttonSize = 18;
-  const _dispatch = createEventDispatcher();
+  const dispatch = createEventDispatcher();
 </script>
 
 <div class="collapseable_modal {isOpen ? '' : 'modal__collapsed'}">
@@ -16,7 +16,7 @@
 				class="modal__close"
 				on:click={() => {
 					isOpen = false;
-					_dispatch('close');
+					dispatch('close');
 				}}
 			>
 				<Minimize2 size={__buttonSize} />
@@ -27,7 +27,7 @@
 				class="modal__open"
 				on:click={() => {
 					isOpen = true;
-					_dispatch('open');
+					dispatch('open');
 				}}
 			>
 				<svelte:component this={collapsedIcon} size={__buttonSize} />

--- a/website/src/components/LayerToggle.svelte
+++ b/website/src/components/LayerToggle.svelte
@@ -16,7 +16,8 @@
 	<img src={image} alt="Layer toggle" />
 </button>
 
-<style>
+<style lang="scss">
+	@use "../styles/variables.scss" as *;
 	button {
 		all: unset;
 		cursor: pointer;
@@ -54,7 +55,7 @@
 			}
 		}
 	}
-	@media /* mobile-only */ (max-width: 600px) {
+	@media /* mobile-only */ (max-width: $mobile-break) {
 		.layer_toggle {
 			width: 2.75rem;
 			height: 2.75rem;

--- a/website/src/components/LayerToggle.svelte
+++ b/website/src/components/LayerToggle.svelte
@@ -54,4 +54,10 @@
 			}
 		}
 	}
+	@media /* mobile-only */ (max-width: 600px) {
+		.layer_toggle {
+			width: 2.75rem;
+			height: 2.75rem;
+		}
+	}
 </style>

--- a/website/src/components/SearchBox.svelte
+++ b/website/src/components/SearchBox.svelte
@@ -49,7 +49,8 @@
 	</button>
 </div>
 
-<style>
+<style lang="scss">
+	@use "../styles/variables.scss" as *;
 	#search-box {
 		position: absolute;
 		width: 300px;
@@ -68,7 +69,7 @@
 	}
 
 	/* Mobile: search behaves like a compact icon button that expands into the full input */
-	@media (max-width: 730px) {
+	@media (max-width: $mobile-break) {
 		#search-box {
 			width: 2.75rem;
 			height: 2.5rem;

--- a/website/src/components/SearchBox.svelte
+++ b/website/src/components/SearchBox.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { Search } from '@lucide/svelte';
   import { MapboxSearchBox } from '@mapbox/search-js-web';
+  import { onMount } from 'svelte';
   import { state } from '../state.svelte.ts';
   import { disablePointer } from '../utils.ts';
 

--- a/website/src/components/SearchBox.svelte
+++ b/website/src/components/SearchBox.svelte
@@ -68,7 +68,7 @@
 	}
 
 	/* Mobile: search behaves like a compact icon button that expands into the full input */
-	@media (max-width: 700px) { /* maybe 730 waiting on tom */
+	@media (max-width: 730px) {
 		#search-box {
 			width: 2.75rem;
 			height: 2.5rem;

--- a/website/src/components/SearchBox.svelte
+++ b/website/src/components/SearchBox.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { Search } from '@lucide/svelte';
+  import { MapboxSearchBox } from '@mapbox/search-js-web';
+  import { state } from '../state.svelte.ts';
+  import { disablePointer } from '../utils.ts';
+
+  onMount(() => {
+    const searchBox = new MapboxSearchBox();
+    searchBox.accessToken =
+      'pk.eyJ1IjoidG9tYmgiLCJhIjoiY2p4cWlqNnY1MDFhZDNscXc5YXJpcTJzciJ9.7gGR5t8KEAY0ZoXfTVBcng';
+    searchBox.options = {
+      types: 'poi,place,country',
+      poi_category: 'mountain,natural_feature',
+    };
+    searchBox.addEventListener('retrieve', (e) => {
+      const feature = e.detail;
+      const coordinates = feature.features[0]?.geometry.coordinates;
+      state.map?.flyTo({
+        center: [coordinates[0], coordinates[1]],
+        zoom: 11,
+      });
+      state.isFlying = true;
+
+      disablePointer();
+    });
+
+    /* #search-widget is hidden (display: none) on mobile until the user expands search;
+    we still mount here so the box is ready. Guard in case the node isn't available yet. */
+    const container = document.querySelector('#search-widget');
+    if (container) {
+      // @ts-expect-error: MapboxSearchBox is a custom element
+      container.appendChild(searchBox);
+    }
+  });
+</script>
+
+<div id="search-box" class:is-open={state.isSearchOpen}>
+	<div id="search-widget"></div>
+	<button
+		id="search-toggle"
+		type="button"
+		on:click={() => {
+			state.isSearchOpen = true;
+			state.isInfoOpen = false;
+		}}
+	>
+		<Search size={18} />
+	</button>
+</div>
+
+<style>
+	#search-box {
+		position: absolute;
+		width: 300px;
+		margin-left: 17px;
+		margin-top: 17px;
+	}
+
+	#search-widget {
+		width: 100%;
+	}
+
+	#search-toggle {
+		all: unset;
+		cursor: pointer;
+		display: none;
+	}
+
+	/* Mobile: search behaves like a compact icon button that expands into the full input */
+	@media (max-width: 700px) { /* maybe 730 waiting on tom */
+		#search-box {
+			width: 2.75rem;
+			height: 2.5rem;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			overflow: hidden;
+			background-color: white;
+			border-radius: 3px;
+			z-index: 2;
+		}
+
+		#search-toggle {
+			display: flex;
+			width: 1rem;
+			height: 2.5rem;
+			align-items: center;
+			justify-content: center;
+			color: #141f41;
+		}
+
+		/* collapsed: only icon button visible */
+		#search-widget {
+			display: none;
+		}
+
+		/* expanded: show full widget, hide icon, grow container */
+		#search-box.is-open {
+			width: min(18rem, 80vw);
+			height: auto;
+			overflow: visible;
+			background-color: transparent;
+			border-radius: 0;
+		}
+
+		#search-box.is-open #search-widget {
+			display: block;
+		}
+
+		#search-box.is-open #search-toggle {
+			display: none;
+		}
+	}
+</style>
+

--- a/website/src/state.svelte.ts
+++ b/website/src/state.svelte.ts
@@ -18,6 +18,9 @@ const heatmapConfig: HeatmapConfig = {
   intensity: 1 - 0.5,
 };
 const isFlying = false;
+// Mobile-only events
+const isSearchOpen = false;
+const isInfoOpen = true;
 
 export const state = $state({
   map,
@@ -28,4 +31,6 @@ export const state = $state({
   bruteForceLoadingLine,
   heatmapConfig,
   isFlying,
+  isSearchOpen,
+  isInfoOpen,
 });

--- a/website/src/styles/index.scss
+++ b/website/src/styles/index.scss
@@ -1,5 +1,4 @@
 @use "sass:color";
-
 @use "./variables.scss" as *;
 
 body {
@@ -48,4 +47,18 @@ a {
 
 .maplibregl-canvas {
   background-color: #131e40;
+}
+
+/* Mobile-only tweaks */
+@media (max-width: 600px) {
+  /* Map attribution: make box narrower and text more compact */
+  .maplibregl-ctrl-attrib {
+    max-width: 200px;
+  }
+  .maplibregl-ctrl-attrib-inner {
+    white-space: normal; /* allow wrapping */
+    font-size: 10px;
+    line-height: 1.2;
+    padding: 2px 4px;
+  }
 }

--- a/website/src/styles/index.scss
+++ b/website/src/styles/index.scss
@@ -50,7 +50,7 @@ a {
 }
 
 /* Mobile-only tweaks */
-@media (max-width: 600px) {
+@media (max-width: $mobile-break) {
   /* Map attribution: make box narrower and text more compact */
   .maplibregl-ctrl-attrib {
     max-width: 200px;

--- a/website/src/styles/variables.scss
+++ b/website/src/styles/variables.scss
@@ -2,6 +2,7 @@ $primary-colour: #fd6612;
 $secondary-colour: #141f41;
 $secondary-light: #b8bdd6;
 $longest-line: #5bc0eb;
+$mobile-break: 730px;
 
 :root {
   --primary-colour: #{$primary-colour};


### PR DESCRIPTION
<table>
<tr>
<td><img width="376" height="668" alt="Mobile layout" src="https://github.com/user-attachments/assets/13107513-f4a0-41cf-b453-c0e4fe5a0eb9" /></td>
<td>
- Collapsible Search that closes Info modal when opened<br>
- Controlled info modal that closes search box if opened<br>
- Smaller info block and layer toggles<br>
- Layer toggles in a column<br>
- Compact credits attribution
</td>
</tr>
</table>

Things to highlight:
- I tried to solve the info btns overflow on smaller screen as indicated by the following pic:
<img width="376" height="668" alt="Screenshot 2026-02-10 at 9 31 14 PM" src="https://github.com/user-attachments/assets/4e478d52-c43b-4e6e-9225-c1ae00116958" />

Could not achieve a clean solution without introducing a new mobile layout under [Home.svelte 170](https://github.com/Umpriel/viewview/blob/7525e7849f3a520b36f7e29ef0bbd867c9853fa1/website/src/Home.svelte#L170)
The solution i attempted involved spreading the btns in a single row ( on the height level of btn id="info") but only when the collapsableModal is opened and when the modal is closed, they return to their column stack. This saved vertical space and solved the overflow. This issue arises only on tiny screens such as the iphone SE Dimensions: 375X667

- The terrain toggle might need a prominent border-color because now that it became smaller, it might be harder to see when flying on top of Land. Did not change the color because it's unrelated to mobile layout.